### PR TITLE
feat: Support bracket attribute

### DIFF
--- a/packages/html-fmt-core/index.test.ts
+++ b/packages/html-fmt-core/index.test.ts
@@ -579,4 +579,16 @@ describe('index', () => {
         const result = format(input);
         expect(result).to.eql(`<input value="<TMPL_V escape=HTML objective.id>">\n`);
     });
+
+    it('should support bracket attribute', () => {
+        const input = `<div [attr]="value" [attr2]="value2" [attr3]="value3" [attr4]="value4">`;
+        const result = format(input);
+        expect(result).to.eql(`<div
+    [attr]="value"
+    [attr2]="value2"
+    [attr3]="value3"
+    [attr4]="value4"
+>
+`);
+    });
 });

--- a/packages/html-fmt-core/src/Parser.ts
+++ b/packages/html-fmt-core/src/Parser.ts
@@ -151,7 +151,9 @@ export class Parser {
             || ch === '-'
             || ch === ':'
             || ch === '.'
-            || ch === '!';
+            || ch === '!'
+            || ch === '['
+            || ch === ']';
     }
 
     readTagName(): string {


### PR DESCRIPTION
## Description

I found the VSCode extension today and I am very exited.
I've wanted this for a long time!

I want to use this extension with Angular template html.
When Angular marks bracket as attribute binding,

```html
<div [attr]="value"></div>
```

but then extension enabled, I got error below.

```
L4C21 Unexpected attribute name [ in <view-list-icon at line 4 col 21
```

Would you support Angular binding style?

By the way, Unit test passed in my local machine.

<img width="500" alt="mocha" src="https://user-images.githubusercontent.com/15980747/103273992-f32b7180-4a03-11eb-8b45-4eac3cb7869a.png">

Thanks.